### PR TITLE
Update base `ExternalEncoder` method signature

### DIFF
--- a/turftopic/encoders/base.py
+++ b/turftopic/encoders/base.py
@@ -8,7 +8,7 @@ class ExternalEncoder(ABC):
     """Base class for external encoder models."""
 
     @abstractmethod
-    def encode(sentences: Iterable[str]) -> np.ndarray:
+    def encode(self, sentences: Iterable[str]) -> np.ndarray:
         """Encodes sentences into an embedding matrix.
 
         Parameters


### PR DESCRIPTION
The current method signature is not a class method - all derivatives are instance methods.